### PR TITLE
Use an output buffer so that we can `header()` during the `wp_head` action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 * Requires PHP 7.4.
 * Requires WordPress 5.6.
+* Use output buffer for `wp_head` action to be able to send headers.
 
 ## [1.3.0] - 2020-09-30
 

--- a/h2push.php
+++ b/h2push.php
@@ -31,6 +31,32 @@
 namespace Required\H2Push;
 
 /**
+ * Starts an output buffer for `wp_head`.
+ *
+ * The output buffer is necessary so that we can call `header()` during
+ * the `wp_head` action which is the only action that allows us to collect
+ * all script and style resources.
+ *
+ * @since 2.0.0
+ */
+function start_output_buffer() {
+	ob_start();
+}
+add_action( 'wp_head', __NAMESPACE__ . '\start_output_buffer', 0 );
+
+/**
+ * Stops the output buffer for `wp_head`.
+ *
+ * @since 2.0.0
+ */
+function stop_output_buffer() {
+	if ( ob_get_length() ) {
+		ob_flush();
+	}
+}
+add_action( 'wp_head', __NAMESPACE__ . '\stop_output_buffer', PHP_INT_MAX );
+
+/**
  * Sends preload Link headers for script and style resources.
  *
  * @since 1.0.0


### PR DESCRIPTION
Because we have to use priority 2 for our `wp_head` action, chances are high that headers are already sent. With an output buffer we can workaround this limitation.

Fixes #8.