### PR TITLE
Support resources with custom `as`,`type`, `crossorigin` and `nopush` parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * New `h2push.as_header` filter to define whether to use Link headers or the `<link>` element.
 * New `h2push.push_resources` filter to customize URLs for resources to push.
-* Support resources with custom `as`,`type`, `crossorigin` and `nopush` parameters.
+* Support resources with custom `as`, `type`, `crossorigin` and `nopush` parameters.
 
 ## [1.3.0] - 2020-09-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 * New `h2push.as_header` filter to define whether to use Link headers or the `<link>` element.
-* Add `h2push.push_resources` filter to customize URLs for resources to preload.
+* New `h2push.push_resources` filter to customize URLs for resources to push.
+* Support resources with custom `as`,`type`, `crossorigin` and `nopush` parameters.
 
 ## [1.3.0] - 2020-09-30
 

--- a/README.md
+++ b/README.md
@@ -5,3 +5,56 @@
 Sends Link headers to bring HTTP/2 Server Push for scripts and styles to WordPress. Falls back to `<link>` element if headers are already sent.
 
 ![Screenshot](https://user-images.githubusercontent.com/617637/31279476-7c3dffd6-aaa9-11e7-91d8-57ec4435d067.png)
+
+## Installation
+
+Install the latest version with
+
+`composer install wearerequired/h2push`
+
+The plugin requires at least PHP 7.4 and WordPress 5.6.
+
+## Hooks reference
+
+### `h2push.as_header`
+
+By default the plugin will use the Link header if no headers are sent yet and falls back to the `<link>` element. To change this behavior you can use the `h2push.as_header` filter. Example:
+
+```php
+// Force H2 Push to always use the `<link>` element.
+add_filter( 'h2push.as_header', '__return_false' );
+```
+
+This filter is also useful if the server doesn't support HTTP/2 yet and you still want to benefit from preloading.
+
+### `h2push.push_resources`
+
+By default the plugin collects all enqueued scripts and styles which are have been registered before or at the `wp_enqueue_scripts` hook. The `h2push.push_resources` filters allows to customize the list of resources. Example:
+
+```php
+/**
+ * Add web font and hero image to the list of resources to push/preload.
+ *
+ * @param array $resources List of resources.
+ * @return array List of resources.
+ */
+function my_theme_push_resources( array $resources ): array {
+	// Push web font.
+	$resources[] = [
+		'href' => '/wp-content/themes/my-theme/assets/fonts/fancy.woff2?a6htkf',
+		'as'   => 'font',
+		'type' => 'font/woff2',
+		'crossorigin',
+	];
+
+	if ( is_front_page() ) {
+		// Push hero image.
+		$resources[] = [
+			'href' => '/wp-content/themes/my-theme/assets/images/hero.webp',
+			'as'   => 'image',
+			'type' => 'image/webp',
+		];
+	}
+}
+add_filter( 'h2push.push_resources', 'my_theme_push_resources' );
+```


### PR DESCRIPTION
Fixes #19.