### PR TITLE
Introduce `h2push.is_allowed_push_host` filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+* New `h2push.is_allowed_push_host` filter to allow external files to be preloaded.
+
 ## [2.0.0] - 2021-04-21
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -63,3 +63,21 @@ function my_theme_push_resources( array $resources ): array {
 }
 add_filter( 'h2push.push_resources', 'my_theme_push_resources' );
 ```
+
+### `h2push.is_allowed_push_host`
+
+By default the plugin only sends push requests for local resources where the asset URL matches the home URL. To change this behavior you can use the `h2push.is_allowed_push_host` filter. Example:
+
+```php
+/**
+ * Allow resources from example.org to be pushed/preloaded too.
+ *
+ * @param bool   $is_allowed Whether the host should be allowed. Default true for local resources.
+ * @param string $host       The host name of the resource.
+ * @return bool Whether the host should be allowed.
+ */
+function my_theme_is_allowed_push_host( $is_allowed, $host ) {
+	return $is_allowed || 'example.org' === $host;
+}
+add_filter( 'h2push.is_allowed_push_host', 'my_theme_is_allowed_push_host' );
+```

--- a/h2push.php
+++ b/h2push.php
@@ -196,8 +196,10 @@ function get_push_resources(): array {
 
 		// Check if it's a local resource.
 		if ( '/' !== $src[0] ) {
-			$src_host = wp_parse_url( $src, PHP_URL_HOST );
-			if ( $home_url_host !== $src_host ) {
+			$src_host        = wp_parse_url( $src, PHP_URL_HOST );
+			$is_local        = $home_url_host === $src_host;
+			$is_allowed_host = apply_filters( 'h2push.is_allowed_push_host', $is_local, $src_host );
+			if ( ! $is_allowed_host ) {
 				continue;
 			}
 		}
@@ -244,8 +246,10 @@ function get_push_resources(): array {
 
 		// Check if it's a local resource.
 		if ( '/' !== $src[0] ) {
-			$src_host = wp_parse_url( $src, PHP_URL_HOST );
-			if ( $home_url_host !== $src_host ) {
+			$src_host        = wp_parse_url( $src, PHP_URL_HOST );
+			$is_local        = $home_url_host === $src_host;
+			$is_allowed_host = apply_filters( 'h2push.is_allowed_push_host', $is_local, $src_host );
+			if ( ! $is_allowed_host ) {
 				continue;
 			}
 		}


### PR DESCRIPTION
The filter can be used to preload resources from external hosts.