### PR TITLE
Fix incorrect handling of output buffer for `wp_head` action when stacked buffers are used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+* Fix incorrect handling of output buffer for `wp_head` action when stacked buffers are used.
+
 ### Added
 * New `h2push.is_allowed_push_host` filter to allow external files to be preloaded.
 

--- a/h2push.php
+++ b/h2push.php
@@ -51,7 +51,7 @@ add_action( 'wp_head', __NAMESPACE__ . '\start_output_buffer', 0 );
  */
 function stop_output_buffer(): void {
 	if ( ob_get_length() ) {
-		ob_flush();
+		echo ob_get_clean(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 }
 add_action( 'wp_head', __NAMESPACE__ . '\stop_output_buffer', PHP_INT_MAX );

--- a/h2push.php
+++ b/h2push.php
@@ -51,7 +51,7 @@ add_action( 'wp_head', __NAMESPACE__ . '\start_output_buffer', 0 );
  */
 function stop_output_buffer(): void {
 	if ( ob_get_length() ) {
-		echo ob_get_clean(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		ob_end_flush();
 	}
 }
 add_action( 'wp_head', __NAMESPACE__ . '\stop_output_buffer', PHP_INT_MAX );


### PR DESCRIPTION
Alternative for #29.

Fixes #28.